### PR TITLE
Converting AFDateHelperExetension to Swift 3.2 / 4.0 syntax.

### DIFF
--- a/AFDateHelper.xcodeproj/project.pbxproj
+++ b/AFDateHelper.xcodeproj/project.pbxproj
@@ -343,7 +343,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.allforces.AFDateHelperDemo;
 				PRODUCT_NAME = AFDateHelper;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -362,7 +362,7 @@
 				METAL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.allforces.AFDateHelperDemo;
 				PRODUCT_NAME = AFDateHelper;
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -391,7 +391,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -421,7 +421,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.allforces.AFDateHelper;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};

--- a/AFDateHelper/AFDateExtension.swift
+++ b/AFDateHelper/AFDateExtension.swift
@@ -1,7 +1,7 @@
 //
 //  AFDateExtension.swift
 //
-//  Version 3.3.1
+//  Version 3.5.3
 //
 //  Created by Melvin Rivera on 7/15/14.
 //  Copyright (c) 2014. All rights reserved.
@@ -15,16 +15,16 @@ let RSSFormat = "EEE, d MMM yyyy HH:mm:ss ZZZ" // "Fri, 09 Sep 2011 15:26:08 +02
 let AltRSSFormat = "d MMM yyyy HH:mm:ss ZZZ" // "09 Sep 2011 15:26:08 +0200"
 
 public enum ISO8601Format: String {
-    
+
     case Year = "yyyy" // 1997
     case YearMonth = "yyyy-MM" // 1997-07
     case Date = "yyyy-MM-dd" // 1997-07-16
     case DateTime = "yyyy-MM-dd'T'HH:mmZ" // 1997-07-16T19:20+01:00
     case DateTimeSec = "yyyy-MM-dd'T'HH:mm:ssZ" // 1997-07-16T19:20:30+01:00
     case DateTimeMilliSec = "yyyy-MM-dd'T'HH:mm:ss.SSSZ" // 1997-07-16T19:20:30.45+01:00
-    
+
     init(dateString:String) {
-        switch dateString.characters.count {
+        switch dateString.count {
         case 4:
             self = ISO8601Format(rawValue: ISO8601Format.Year.rawValue)!
         case 7:
@@ -42,799 +42,867 @@ public enum ISO8601Format: String {
 }
 
 public enum DateFormat {
-    case ISO8601(ISO8601Format?), DotNet, RSS, AltRSS, Custom(String)
+    case iso8601(ISO8601Format?), dotNet, rss, altRSS, custom(String)
 }
 
 public enum TimeZone {
-    case Local, UTC
+    case local, utc
 }
 
-public extension NSDate {
-    
+public extension Date {
+
     // MARK: Intervals In Seconds
-    private class func minuteInSeconds() -> Double { return 60 }
-    private class func hourInSeconds() -> Double { return 3600 }
-    private class func dayInSeconds() -> Double { return 86400 }
-    private class func weekInSeconds() -> Double { return 604800 }
-    private class func yearInSeconds() -> Double { return 31556926 }
-    
+    private static func minuteInSeconds() -> Double { return 60 }
+    private static func hourInSeconds() -> Double { return 3600 }
+    private static func dayInSeconds() -> Double { return 86400 }
+    private static func weekInSeconds() -> Double { return 604800 }
+    private static func yearInSeconds() -> Double { return 31556926 }
+
     // MARK: Components
-    private class func componentFlags() -> NSCalendarUnit { return [NSCalendarUnit.Year, NSCalendarUnit.Month, NSCalendarUnit.Day, NSCalendarUnit.WeekOfYear, NSCalendarUnit.Hour, NSCalendarUnit.Minute, NSCalendarUnit.Second, NSCalendarUnit.Weekday, NSCalendarUnit.WeekdayOrdinal, NSCalendarUnit.WeekOfYear] }
-    
-    private class func components(fromDate fromDate: NSDate) -> NSDateComponents! {
-        return NSCalendar.currentCalendar().components(NSDate.componentFlags(), fromDate: fromDate)
+    private static func componentFlags() -> Set<Calendar.Component> { return [Calendar.Component.year, Calendar.Component.month, Calendar.Component.day, Calendar.Component.weekOfYear, Calendar.Component.hour, Calendar.Component.minute, Calendar.Component.second, Calendar.Component.weekday, Calendar.Component.weekdayOrdinal, Calendar.Component.weekOfYear] }
+
+    private static func components(_ fromDate: Date) -> DateComponents! {
+        return Calendar.current.dateComponents(Date.componentFlags(), from: fromDate)
     }
-    
-    private func components() -> NSDateComponents  {
-        return NSDate.components(fromDate: self)!
+
+    private func components() -> DateComponents  {
+        return Date.components(self)!
     }
-    
+
     // MARK: Date From String
-    
+
     /**
-    Creates a date based on a string and a formatter type. You can ise .ISO8601(nil) to for deducting an ISO8601Format automatically.
-    
-    - Parameter fromString Date string i.e. "16 July 1972 6:12:00".
-    - Parameter format The Date Formatter type can be .ISO8601(ISO8601Format?), .DotNet, .RSS, .AltRSS or Custom(String).
-    - Parameter timeZone: The time zone to interpret fromString can be .Local, .UTC applies to Custom format only
-    
-    - Returns A new date
-    */
-    
-    convenience init(fromString string: String, format:DateFormat, timeZone: TimeZone = .Local)
+     Creates a date based on a string and a formatter type. You can ise .ISO8601(nil) to for deducting an ISO8601Format automatically.
+
+     - Parameter fromString Date string i.e. "16 July 1972 6:12:00".
+     - Parameter format The Date Formatter type can be .ISO8601(ISO8601Format?), .DotNet, .RSS, .AltRSS or Custom(String).
+     - Parameter timeZone: The time zone to interpret fromString can be .Local, .UTC applies to Custom format only
+
+     - Returns A new date
+     */
+
+    init(fromString string: String, format:DateFormat, timeZone: TimeZone = .local)
     {
         if string.isEmpty {
             self.init()
             return
         }
-        
+
         let string = string as NSString
-        
-        let zone: NSTimeZone
-        
+
+        let zone: Foundation.TimeZone
+
         switch timeZone {
-        case .Local:
-            zone = NSTimeZone.localTimeZone()
-        case .UTC:
-            zone = NSTimeZone(forSecondsFromGMT: 0)
+        case .local:
+            zone = Foundation.NSTimeZone.local
+        case .utc:
+            zone = Foundation.TimeZone(secondsFromGMT: 0)!
         }
-        
+
         switch format {
-            
-        case .DotNet:
-            
-            let startIndex = string.rangeOfString("(").location + 1
-            let endIndex = string.rangeOfString(")").location
+
+        case .dotNet:
+
+            let startIndex = string.range(of: "(").location + 1
+            let endIndex = string.range(of: ")").location
             let range = NSRange(location: startIndex, length: endIndex-startIndex)
-            let milliseconds = (string.substringWithRange(range) as NSString).longLongValue
-            let interval = NSTimeInterval(milliseconds / 1000)
+            let milliseconds = (string.substring(with: range) as NSString).longLongValue
+            let interval = TimeInterval(milliseconds / 1000)
             self.init(timeIntervalSince1970: interval)
-            
-        case .ISO8601(let isoFormat):
-            
+
+        case .iso8601(let isoFormat):
+
             let dateFormat = (isoFormat != nil) ? isoFormat! : ISO8601Format(dateString: string as String)
-            let formatter = NSDate.formatter(format: dateFormat.rawValue)
-            formatter.locale = NSLocale(localeIdentifier: "en_US_POSIX")
-            formatter.timeZone = NSTimeZone.localTimeZone()
+            let formatter = Date.formatter(dateFormat.rawValue)
+            formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+            formatter.timeZone = Foundation.NSTimeZone.local
             formatter.dateFormat = dateFormat.rawValue
-            if let date = formatter.dateFromString(string as String) {
-                self.init(timeInterval:0, sinceDate:date)
+            if let date = formatter.date(from: string as String) {
+                self.init(timeInterval:0, since:date)
             } else {
                 self.init()
             }
-            
-        case .RSS:
-            
+
+        case .rss:
+
             var s  = string
             if string.hasSuffix("Z") {
-                s = s.substringToIndex(s.length-1) + "GMT"
+                s = s.substring(to: s.length-1).appending("GMT") as NSString
             }
-            let formatter = NSDate.formatter(format: RSSFormat)
-            if let date = formatter.dateFromString(string as String) {
-                self.init(timeInterval:0, sinceDate:date)
+            let formatter = Date.formatter(RSSFormat)
+            if let date = formatter.date(from: string as String) {
+                self.init(timeInterval:0, since:date)
             } else {
                 self.init()
             }
-            
-        case .AltRSS:
-            
+
+        case .altRSS:
+
             var s  = string
             if string.hasSuffix("Z") {
-                s = s.substringToIndex(s.length-1) + "GMT"
+                s = s.substring(to: s.length-1).appending("GMT") as NSString
             }
-            let formatter = NSDate.formatter(format: AltRSSFormat)
-            if let date = formatter.dateFromString(string as String) {
-                self.init(timeInterval:0, sinceDate:date)
+            let formatter = Date.formatter(AltRSSFormat)
+            if let date = formatter.date(from: string as String) {
+                self.init(timeInterval:0, since:date)
             } else {
                 self.init()
             }
-            
-        case .Custom(let dateFormat):
-            
-            let formatter = NSDate.formatter(format: dateFormat, timeZone: zone)
-            if let date = formatter.dateFromString(string as String) {
-                self.init(timeInterval:0, sinceDate:date)
+
+        case .custom(let dateFormat):
+
+            let formatter = Date.formatter(dateFormat, timeZone: zone)
+            if let date = formatter.date(from: string as String) {
+                self.init(timeInterval:0, since:date)
             } else {
                 self.init()
             }
         }
     }
-    
-    
-    
+
+
+
     // MARK: Comparing Dates
-    
+
     /**
-    Returns true if dates are equal while ignoring time.
-    
-    - Parameter date: The Date to compare.
-    */
-    func isEqualToDateIgnoringTime(date: NSDate) -> Bool
+     Returns true if dates are equal while ignoring time.
+
+     - Parameter date: The Date to compare.
+     */
+    func isEqualToDateIgnoringTime(_ date: Date) -> Bool
     {
-        let comp1 = NSDate.components(fromDate: self)
-        let comp2 = NSDate.components(fromDate: date)
-        return ((comp1.year == comp2.year) && (comp1.month == comp2.month) && (comp1.day == comp2.day))
+        let comp1 = Date.components(self)
+        let comp2 = Date.components(date)
+        return ((comp1!.year == comp2!.year) && (comp1!.month == comp2!.month) && (comp1!.day == comp2!.day))
     }
-    
+
     /**
-    Returns Returns true if date is today.
-    */
+     Returns Returns true if date is today.
+     */
     func isToday() -> Bool
     {
-        return self.isEqualToDateIgnoringTime(NSDate())
+        return self.isEqualToDateIgnoringTime(Date())
     }
-    
+
     /**
-    Returns true if date is tomorrow.
-    */
+     Returns true if date is tomorrow.
+     */
     func isTomorrow() -> Bool
     {
-        return self.isEqualToDateIgnoringTime(NSDate().dateByAddingDays(1))
+        return self.isEqualToDateIgnoringTime(Date().dateByAddingDays(1))
     }
-    
+
     /**
-    Returns true if date is yesterday.
-    */
+     Returns true if date is yesterday.
+     */
     func isYesterday() -> Bool
     {
-        return self.isEqualToDateIgnoringTime(NSDate().dateBySubtractingDays(1))
+        return self.isEqualToDateIgnoringTime(Date().dateBySubtractingDays(1))
     }
-    
+
     /**
-    Returns true if date are in the same week.
-     
-    - Parameter date: The date to compare.
-    */
-    func isSameWeekAsDate(date: NSDate) -> Bool
+     Returns true if date are in the same week.
+
+     - Parameter date: The date to compare.
+     */
+    func isSameWeekAsDate(_ date: Date) -> Bool
     {
-        let comp1 = NSDate.components(fromDate: self)
-        let comp2 = NSDate.components(fromDate: date)
+        let comp1 = Date.components(self)
+        let comp2 = Date.components(date)
         // Must be same week. 12/31 and 1/1 will both be week "1" if they are in the same week
-        if comp1.weekOfYear != comp2.weekOfYear {
+        if comp1?.weekOfYear != comp2?.weekOfYear {
             return false
         }
         // Must have a time interval under 1 week
-        return abs(self.timeIntervalSinceDate(date)) < NSDate.weekInSeconds()
+        return abs(self.timeIntervalSince(date)) < Date.weekInSeconds()
     }
-    
+
     /**
-    Returns true if date is this week.
-    */
+     Returns true if date is this week.
+     */
     func isThisWeek() -> Bool
     {
-        return self.isSameWeekAsDate(NSDate())
+        return self.isSameWeekAsDate(Date())
     }
-    
+
     /**
-    Returns true if date is next week.
-    */
+     Returns true if date is next week.
+     */
     func isNextWeek() -> Bool
     {
-        let interval: NSTimeInterval = NSDate().timeIntervalSinceReferenceDate + NSDate.weekInSeconds()
-        let date = NSDate(timeIntervalSinceReferenceDate: interval)
+        let interval: TimeInterval = Date().timeIntervalSinceReferenceDate + Date.weekInSeconds()
+        let date = Date(timeIntervalSinceReferenceDate: interval)
         return self.isSameWeekAsDate(date)
     }
-    
+
     /**
-    Returns true if date is last week.
-    */
+     Returns true if date is last week.
+     */
     func isLastWeek() -> Bool
     {
-        let interval: NSTimeInterval = NSDate().timeIntervalSinceReferenceDate - NSDate.weekInSeconds()
-        let date = NSDate(timeIntervalSinceReferenceDate: interval)
+        let interval: TimeInterval = Date().timeIntervalSinceReferenceDate - Date.weekInSeconds()
+        let date = Date(timeIntervalSinceReferenceDate: interval)
         return self.isSameWeekAsDate(date)
     }
-    
+
     /**
-    Returns true if dates are in the same year.
-    
-    - Parameter date: The date to compare.
-    */
-    func isSameYearAsDate(date: NSDate) -> Bool
-    {
-        let comp1 = NSDate.components(fromDate: self)
-        let comp2 = NSDate.components(fromDate: date)
-        return (comp1.year == comp2.year)
-    }
-    
-    /**
-    Returns true if date is this year.
-    */
-    func isThisYear() -> Bool
-    {
-        return self.isSameYearAsDate(NSDate())
-    }
-    
-    /**
-    Returns true if date is next year.
-    */
-    func isNextYear() -> Bool
-    {
-        let comp1 = NSDate.components(fromDate: self)
-        let comp2 = NSDate.components(fromDate: NSDate())
-        return (comp1.year == comp2.year + 1)
-    }
-    
-    /**
-    Returns true if date is last year.
-    */
-    func isLastYear() -> Bool
-    {
-        let comp1 = NSDate.components(fromDate: self)
-        let comp2 = NSDate.components(fromDate: NSDate())
-        return (comp1.year == comp2.year - 1)
-    }
-    
-    /**
-    Returns true if date is earlier than date.
-    
-    - Parameter date: The date to compare.
-    */
-    func isEarlierThanDate(date: NSDate) -> Bool
-    {
-        return self.earlierDate(date) == self
-    }
-    
-    /**
-     Returns true if date is later than date.
-     
+     Returns true if dates are in the same year.
+
      - Parameter date: The date to compare.
      */
-    func isLaterThanDate(date: NSDate) -> Bool
+    func isSameYearAsDate(_ date: Date) -> Bool
     {
-        return self.laterDate(date) == self
+        let comp1 = Date.components(self)
+        let comp2 = Date.components(date)
+        return comp1!.year == comp2!.year
     }
-    
+
     /**
-    Returns true if date is in future.
-    */
+     Returns true if dates are in the same month
+
+     - Parameter date: The date to compare
+     */
+    func isSameMonthAsDate(_ date: Date) -> Bool
+    {
+        let comp1 = Date.components(self)
+        let comp2 = Date.components(date)
+
+        return comp1!.year == comp2!.year && comp1!.month == comp2!.month
+    }
+
+    /**
+     Returns true if date is this year.
+     */
+    func isThisYear() -> Bool
+    {
+        return self.isSameYearAsDate(Date())
+    }
+
+    /**
+     Returns true if date is next year.
+     */
+    func isNextYear() -> Bool
+    {
+        let comp1 = Date.components(self)
+        let comp2 = Date.components(Date())
+        return (comp1!.year! == comp2!.year! + 1)
+    }
+
+    /**
+     Returns true if date is last year.
+     */
+    func isLastYear() -> Bool
+    {
+        let comp1 = Date.components(self)
+        let comp2 = Date.components(Date())
+        return (comp1!.year! == comp2!.year! - 1)
+    }
+
+    /**
+     Returns true if date is earlier than date.
+
+     - Parameter date: The date to compare.
+     */
+    func isEarlierThanDate(_ date: Date) -> Bool
+    {
+        return (self as NSDate).earlierDate(date) == self
+    }
+
+    /**
+     Returns true if date is later than date.
+
+     - Parameter date: The date to compare.
+     */
+    func isLaterThanDate(_ date: Date) -> Bool
+    {
+        return (self as NSDate).laterDate(date) == self
+    }
+
+    /**
+     Returns true if date is in future.
+     */
     func isInFuture() -> Bool
     {
-        return self.isLaterThanDate(NSDate())
+        return self.isLaterThanDate(Date())
     }
-    
+
     /**
-    Returns true if date is in past.
-    */
+     Returns true if date is in past.
+     */
     func isInPast() -> Bool
     {
-        return self.isEarlierThanDate(NSDate())
+        return self.isEarlierThanDate(Date())
     }
-    
-    
+
+
     // MARK: Adjusting Dates
-    
+
     /**
-    Creates a new date by a adding days.
-    
-    - Parameter days: The number of days to add.
-    - Returns A new date object.
-    */
-    func dateByAddingDays(days: Int) -> NSDate
+     Creates a new date by a adding months.
+
+     - Parameter days: The number of months to add.
+     - Returns A new date object.
+     */
+    func dateByAddingMonths(_ months: Int) -> Date
     {
-        let dateComp = NSDateComponents()
+        var dateComp = DateComponents()
+        dateComp.month = months
+        return Calendar.current.date(byAdding: dateComp, to: self)!
+    }
+
+    /**
+     Creates a new date by a substracting months.
+
+     - Parameter days: The number of months to substract.
+     - Returns A new date object.
+     */
+    func dateBySubtractingMonths(_ months: Int) -> Date
+    {
+        var dateComp = DateComponents()
+        dateComp.month = (months * -1)
+        return Calendar.current.date(byAdding: dateComp, to: self)!
+    }
+
+    /**
+     Creates a new date by a adding weeks.
+
+     - Parameter days: The number of weeks to add.
+     - Returns A new date object.
+     */
+    func dateByAddingWeeks(_ weeks: Int) -> Date
+    {
+        var dateComp = DateComponents()
+        dateComp.day = 7 * weeks
+        return Calendar.current.date(byAdding: dateComp, to: self)!
+    }
+
+    /**
+     Creates a new date by a substracting weeks.
+
+     - Parameter days: The number of weeks to substract.
+     - Returns A new date object.
+     */
+    func dateBySubtractingWeeks(_ weeks: Int) -> Date
+    {
+        var dateComp = DateComponents()
+        dateComp.day = ((7 * weeks) * -1)
+        return Calendar.current.date(byAdding: dateComp, to: self)!
+    }
+
+    /**
+     Creates a new date by a adding days.
+
+     - Parameter days: The number of days to add.
+     - Returns A new date object.
+     */
+    func dateByAddingDays(_ days: Int) -> Date
+    {
+        var dateComp = DateComponents()
         dateComp.day = days
-        return NSCalendar.currentCalendar().dateByAddingComponents(dateComp, toDate: self, options: NSCalendarOptions(rawValue: 0))!
+        return Calendar.current.date(byAdding: dateComp, to: self)!
     }
-    
+
     /**
-    Creates a new date by a substracting days.
-    
-    - Parameter days: The number of days to substract.
-    - Returns A new date object.
-    */
-    func dateBySubtractingDays(days: Int) -> NSDate
+     Creates a new date by a substracting days.
+
+     - Parameter days: The number of days to substract.
+     - Returns A new date object.
+     */
+    func dateBySubtractingDays(_ days: Int) -> Date
     {
-        let dateComp = NSDateComponents()
+        var dateComp = DateComponents()
         dateComp.day = (days * -1)
-        return NSCalendar.currentCalendar().dateByAddingComponents(dateComp, toDate: self, options: NSCalendarOptions(rawValue: 0))!
+        return Calendar.current.date(byAdding: dateComp, to: self)!
     }
-    
+
     /**
-    Creates a new date by a adding hours.
-    
-    - Parameter days: The number of hours to add.
-    - Returns A new date object.
-    */
-    func dateByAddingHours(hours: Int) -> NSDate
+     Creates a new date by a adding hours.
+
+     - Parameter days: The number of hours to add.
+     - Returns A new date object.
+     */
+    func dateByAddingHours(_ hours: Int) -> Date
     {
-        let dateComp = NSDateComponents()
+        var dateComp = DateComponents()
         dateComp.hour = hours
-        return NSCalendar.currentCalendar().dateByAddingComponents(dateComp, toDate: self, options: NSCalendarOptions(rawValue: 0))!
+        return Calendar.current.date(byAdding: dateComp, to: self)!
     }
-    
+
     /**
-    Creates a new date by substracting hours.
-    
-    - Parameter days: The number of hours to substract.
-    - Returns A new date object.
-    */
-    func dateBySubtractingHours(hours: Int) -> NSDate
+     Creates a new date by substracting hours.
+
+     - Parameter days: The number of hours to substract.
+     - Returns A new date object.
+     */
+    func dateBySubtractingHours(_ hours: Int) -> Date
     {
-        let dateComp = NSDateComponents()
+        var dateComp = DateComponents()
         dateComp.hour = (hours * -1)
-        return NSCalendar.currentCalendar().dateByAddingComponents(dateComp, toDate: self, options: NSCalendarOptions(rawValue: 0))!
+        return Calendar.current.date(byAdding: dateComp, to: self)!
     }
-    
+
     /**
-    Creates a new date by adding minutes.
-    
-    - Parameter days: The number of minutes to add.
-    - Returns A new date object.
-    */
-    func dateByAddingMinutes(minutes: Int) -> NSDate
+     Creates a new date by adding minutes.
+
+     - Parameter days: The number of minutes to add.
+     - Returns A new date object.
+     */
+    func dateByAddingMinutes(_ minutes: Int) -> Date
     {
-        let dateComp = NSDateComponents()
+        var dateComp = DateComponents()
         dateComp.minute = minutes
-        return NSCalendar.currentCalendar().dateByAddingComponents(dateComp, toDate: self, options: NSCalendarOptions(rawValue: 0))!
+        return Calendar.current.date(byAdding: dateComp, to: self)!
     }
-    
+
     /**
-    Creates a new date by substracting minutes.
-    
-    - Parameter days: The number of minutes to add.
-    - Returns A new date object.
-    */
-    func dateBySubtractingMinutes(minutes: Int) -> NSDate
+     Creates a new date by substracting minutes.
+
+     - Parameter days: The number of minutes to add.
+     - Returns A new date object.
+     */
+    func dateBySubtractingMinutes(_ minutes: Int) -> Date
     {
-        let dateComp = NSDateComponents()
+        var dateComp = DateComponents()
         dateComp.minute = (minutes * -1)
-        return NSCalendar.currentCalendar().dateByAddingComponents(dateComp, toDate: self, options: NSCalendarOptions(rawValue: 0))!
+        return Calendar.current.date(byAdding: dateComp, to: self)!
     }
-    
+
     /**
      Creates a new date by adding seconds.
-     
+
      - Parameter seconds: The number of seconds to add.
      - Returns A new date object.
      */
-    func dateByAddingSeconds(seconds: Int) -> NSDate
+    func dateByAddingSeconds(_ seconds: Int) -> Date
     {
-        let dateComp = NSDateComponents()
+        var dateComp = DateComponents()
         dateComp.second = seconds
-        return NSCalendar.currentCalendar().dateByAddingComponents(dateComp, toDate: self, options: NSCalendarOptions(rawValue: 0))!
+        return Calendar.current.date(byAdding: dateComp, to: self)!
     }
-    
+
     /**
      Creates a new date by substracting seconds.
-     
+
      - Parameter days: The number of seconds to substract.
      - Returns A new date object.
      */
-    func dateBySubtractingSeconds(seconds: Int) -> NSDate
+    func dateBySubtractingSeconds(_ seconds: Int) -> Date
     {
-        let dateComp = NSDateComponents()
+        var dateComp = DateComponents()
         dateComp.second = (seconds * -1)
-        return NSCalendar.currentCalendar().dateByAddingComponents(dateComp, toDate: self, options: NSCalendarOptions(rawValue: 0))!
+        return Calendar.current.date(byAdding: dateComp, to: self)!
     }
-    
+
     /**
-    Creates a new date from the start of the day.
-    
-    - Returns A new date object.
-    */
-    func dateAtStartOfDay() -> NSDate
+     Creates a new date from the start of the day.
+
+     - Returns A new date object.
+     */
+    func dateAtStartOfDay() -> Date
     {
-        let components = self.components()
+        var components = self.components()
         components.hour = 0
         components.minute = 0
         components.second = 0
-        return NSCalendar.currentCalendar().dateFromComponents(components)!
+        return Calendar.current.date(from: components)!
     }
-    
+
     /**
-    Creates a new date from the end of the day.
-    
-    - Returns A new date object.
-    */
-    func dateAtEndOfDay() -> NSDate
+     Creates a new date from the end of the day.
+
+     - Returns A new date object.
+     */
+    func dateAtEndOfDay() -> Date
     {
-        let components = self.components()
+        var components = self.components()
         components.hour = 23
         components.minute = 59
         components.second = 59
-        return NSCalendar.currentCalendar().dateFromComponents(components)!
+        return Calendar.current.date(from: components)!
     }
-    
+
     /**
-    Creates a new date from the start of the week.
-    
-    - Returns A new date object.
-    */
-    func dateAtStartOfWeek() -> NSDate
+     Creates a new date from the start of the week.
+
+     - Returns A new date object.
+     */
+    func dateAtStartOfWeek() -> Date
     {
-        let flags :NSCalendarUnit = [NSCalendarUnit.Year, NSCalendarUnit.Month, NSCalendarUnit.WeekOfYear, NSCalendarUnit.Weekday]
-        let components = NSCalendar.currentCalendar().components(flags, fromDate: self)
-        components.weekday = NSCalendar.currentCalendar().firstWeekday
+        let flags: Set<Calendar.Component> = [Calendar.Component.year, Calendar.Component.month, Calendar.Component.weekOfYear, Calendar.Component.weekday]
+        var components = Calendar.current.dateComponents(flags, from: self)
+        components.weekday = Calendar.current.firstWeekday
         components.hour = 0
         components.minute = 0
         components.second = 0
-        return NSCalendar.currentCalendar().dateFromComponents(components)!
+        return Calendar.current.date(from: components)!
     }
-    
+
     /**
-    Creates a new date from the end of the week.
-    
-    - Returns A new date object.
-    */
-    func dateAtEndOfWeek() -> NSDate
+     Creates a new date from the end of the week.
+
+     - Returns A new date object.
+     */
+    func dateAtEndOfWeek() -> Date
     {
-        let flags :NSCalendarUnit = [NSCalendarUnit.Year, NSCalendarUnit.Month, NSCalendarUnit.WeekOfYear, NSCalendarUnit.Weekday]
-        let components = NSCalendar.currentCalendar().components(flags, fromDate: self)
-        components.weekday = NSCalendar.currentCalendar().firstWeekday + 6
+        let flags: Set<Calendar.Component> = [Calendar.Component.year, Calendar.Component.month, Calendar.Component.weekOfYear, Calendar.Component.weekday]
+        var components = Calendar.current.dateComponents(flags, from: self)
+        components.weekday = Calendar.current.firstWeekday + 6
         components.hour = 0
         components.minute = 0
         components.second = 0
-        return NSCalendar.currentCalendar().dateFromComponents(components)!
+        return Calendar.current.date(from: components)!
     }
-    
+
     /**
-    Creates a new date from the first day of the month
-    
-    - Returns A new date object.
-    */
-    func dateAtTheStartOfMonth() -> NSDate
+     Creates a new date from the first day of the month
+
+     - Returns A new date object.
+     */
+    func dateAtTheStartOfMonth() -> Date
     {
         //Create the date components
-        let components = self.components()
+        var components = self.components()
         components.day = 1
         //Builds the first day of the month
-        let firstDayOfMonthDate :NSDate = NSCalendar.currentCalendar().dateFromComponents(components)!
-        
+        let firstDayOfMonthDate :Date = Calendar.current.date(from: components)!
+
         return firstDayOfMonthDate
-        
+
     }
-    
+
     /**
-    Creates a new date from the last day of the month
-    
-    - Returns A new date object.
-    */
-    func dateAtTheEndOfMonth() -> NSDate {
-        
+     Creates a new date from the last day of the month
+
+     - Returns A new date object.
+     */
+    func dateAtTheEndOfMonth() -> Date {
+
         //Create the date components
-        let components = self.components()
+        var components = self.components()
         //Set the last day of this month
-        components.month += 1
+        components.month = (components.month ?? 0) + 1
         components.day = 0
-        
+
         //Builds the first day of the month
-        let lastDayOfMonth :NSDate = NSCalendar.currentCalendar().dateFromComponents(components)!
-        
+        let lastDayOfMonth :Date = Calendar.current.date(from: components)!
+
         return lastDayOfMonth
-        
+
     }
-    
+
     /**
      Creates a new date based on tomorrow.
-     
+
      - Returns A new date object.
      */
-    class func tomorrow() -> NSDate
+    static func tomorrow() -> Date
     {
-        return NSDate().dateByAddingDays(1).dateAtStartOfDay()
+        return Date().dateByAddingDays(1).dateAtStartOfDay()
     }
-    
+
     /**
      Creates a new date based on yesterdat.
-     
+
      - Returns A new date object.
      */
-    class func yesterday() -> NSDate
+    static func yesterday() -> Date
     {
-        return NSDate().dateBySubtractingDays(1).dateAtStartOfDay()
+        return Date().dateBySubtractingDays(1).dateAtStartOfDay()
     }
-    
+
     /**
      Return a new NSDate object with the new hour, minute and seconds values
-     
+
      :returns: NSDate
      */
-    func setTimeOfDate(hour hour: Int, minute: Int, second: Int) -> NSDate {
-        let components = self.components()
+    func setTimeOfDate(_ hour: Int, minute: Int, second: Int) -> Date {
+        var components = self.components()
         components.hour = hour
         components.minute = minute
         components.second = second
-        return NSCalendar.currentCalendar().dateFromComponents(components)!
+        return Calendar.current.date(from: components)!
     }
-    
-    
+
+
     // MARK: Retrieving Intervals
-    
+
     /**
-    Gets the number of seconds after a date.
-    
-    - Parameter date: the date to compare.
-    - Returns The number of seconds
-    */
-    func secondsAfterDate(date: NSDate) -> Int
+     Gets the number of seconds after a date.
+
+     - Parameter date: the date to compare.
+     - Returns The number of seconds
+     */
+    func secondsAfterDate(_ date: Date) -> Int
     {
-        return Int(self.timeIntervalSinceDate(date))
+        return Int(self.timeIntervalSince(date))
     }
-    
+
     /**
      Gets the number of seconds before a date.
-     
+
      - Parameter date: The date to compare.
      - Returns The number of seconds
      */
-    func secondsBeforeDate(date: NSDate) -> Int
+    func secondsBeforeDate(_ date: Date) -> Int
     {
-        return Int(date.timeIntervalSinceDate(self))
+        return Int(date.timeIntervalSince(self))
     }
-    
+
     /**
-    Gets the number of minutes after a date.
-    
-    - Parameter date: the date to compare.
-    - Returns The number of minutes
-    */
-    func minutesAfterDate(date: NSDate) -> Int
+     Gets the number of minutes after a date.
+
+     - Parameter date: the date to compare.
+     - Returns The number of minutes
+     */
+    func minutesAfterDate(_ date: Date) -> Int
     {
-        let interval = self.timeIntervalSinceDate(date)
-        return Int(interval / NSDate.minuteInSeconds())
+        let interval = self.timeIntervalSince(date)
+        return Int(interval / Date.minuteInSeconds())
     }
-    
+
     /**
-    Gets the number of minutes before a date.
-    
-    - Parameter date: The date to compare.
-    - Returns The number of minutes
-    */
-    func minutesBeforeDate(date: NSDate) -> Int
+     Gets the number of minutes before a date.
+
+     - Parameter date: The date to compare.
+     - Returns The number of minutes
+     */
+    func minutesBeforeDate(_ date: Date) -> Int
     {
-        let interval = date.timeIntervalSinceDate(self)
-        return Int(interval / NSDate.minuteInSeconds())
+        let interval = date.timeIntervalSince(self)
+        return Int(interval / Date.minuteInSeconds())
     }
-    
+
     /**
-    Gets the number of hours after a date.
-    
-    - Parameter date: The date to compare.
-    - Returns The number of hours
-    */
-    func hoursAfterDate(date: NSDate) -> Int
+     Gets the number of hours after a date.
+
+     - Parameter date: The date to compare.
+     - Returns The number of hours
+     */
+    func hoursAfterDate(_ date: Date) -> Int
     {
-        let interval = self.timeIntervalSinceDate(date)
-        return Int(interval / NSDate.hourInSeconds())
+        let interval = self.timeIntervalSince(date)
+        return Int(interval / Date.hourInSeconds())
     }
-    
+
     /**
-    Gets the number of hours before a date.
-    
-    - Parameter date: The date to compare.
-    - Returns The number of hours
-    */
-    func hoursBeforeDate(date: NSDate) -> Int
+     Gets the number of hours before a date.
+
+     - Parameter date: The date to compare.
+     - Returns The number of hours
+     */
+    func hoursBeforeDate(_ date: Date) -> Int
     {
-        let interval = date.timeIntervalSinceDate(self)
-        return Int(interval / NSDate.hourInSeconds())
+        let interval = date.timeIntervalSince(self)
+        return Int(interval / Date.hourInSeconds())
     }
-    
+
     /**
-    Gets the number of days after a date.
-    
-    - Parameter date: The date to compare.
-    - Returns The number of days
-    */
-    func daysAfterDate(date: NSDate) -> Int
+     Gets the number of days after a date.
+
+     - Parameter date: The date to compare.
+     - Returns The number of days
+     */
+    func daysAfterDate(_ date: Date) -> Int
     {
-        let interval = self.timeIntervalSinceDate(date)
-        return Int(interval / NSDate.dayInSeconds())
+        let interval = self.timeIntervalSince(date)
+        return Int(interval / Date.dayInSeconds())
     }
-    
+
     /**
-    Gets the number of days before a date.
-    
-    - Parameter date: The date to compare.
-    - Returns The number of days
-    */
-    func daysBeforeDate(date: NSDate) -> Int
+     Gets the number of days before a date.
+
+     - Parameter date: The date to compare.
+     - Returns The number of days
+     */
+    func daysBeforeDate(_ date: Date) -> Int
     {
-        let interval = date.timeIntervalSinceDate(self)
-        return Int(interval / NSDate.dayInSeconds())
+        let interval = date.timeIntervalSince(self)
+        return Int(interval / Date.dayInSeconds())
     }
-    
-    
+
+
     // MARK: Decomposing Dates
-    
+
     /**
-    Returns the nearest hour.
-    */
+     Returns the nearest hour.
+     */
     func nearestHour () -> Int {
-        let halfHour = NSDate.minuteInSeconds() * 30
+        let halfHour = Date.minuteInSeconds() * 30
         var interval = self.timeIntervalSinceReferenceDate
         if  self.seconds() < 30 {
             interval -= halfHour
         } else {
             interval += halfHour
         }
-        let date = NSDate(timeIntervalSinceReferenceDate: interval)
+        let date = Date(timeIntervalSinceReferenceDate: interval)
         return date.hour()
     }
     /**
-    Returns the year component.
-    */
-    func year () -> Int { return self.components().year  }
+     Returns the year component.
+     */
+    func year () -> Int { return self.components().year!  }
     /**
-    Returns the month component.
-    */
-    func month () -> Int { return self.components().month }
+     Returns the month component.
+     */
+    func month () -> Int { return self.components().month! }
     /**
-    Returns the week of year component.
-    */
-    func week () -> Int { return self.components().weekOfYear }
+     Returns the week of year component.
+     */
+    func week () -> Int { return self.components().weekOfYear! }
     /**
-    Returns the day component.
-    */
-    func day () -> Int { return self.components().day }
+     Returns the day component.
+     */
+    func day () -> Int { return self.components().day! }
     /**
-    Returns the hour component.
-    */
-    func hour () -> Int { return self.components().hour }
+     Returns the hour component.
+     */
+    func hour () -> Int { return self.components().hour! }
     /**
-    Returns the minute component.
-    */
-    func minute () -> Int { return self.components().minute }
+     Returns the minute component.
+     */
+    func minute () -> Int { return self.components().minute! }
     /**
-    Returns the seconds component.
-    */
-    func seconds () -> Int { return self.components().second }
+     Returns the seconds component.
+     */
+    func seconds () -> Int { return self.components().second! }
     /**
-    Returns the weekday component.
-    */
-    func weekday () -> Int { return self.components().weekday }
+     Returns the weekday component.
+     */
+    func weekday () -> Int { return self.components().weekday! }
     /**
-    Returns the nth days component. e.g. 2nd Tuesday of the month is 2.
-    */
-    func nthWeekday () -> Int { return self.components().weekdayOrdinal }
+     Returns the nth days component. e.g. 2nd Tuesday of the month is 2.
+     */
+    func nthWeekday () -> Int { return self.components().weekdayOrdinal! }
     /**
-    Returns the days of the month.
-    */
-    func monthDays () -> Int { return NSCalendar.currentCalendar().rangeOfUnit(NSCalendarUnit.Day, inUnit: NSCalendarUnit.Month, forDate: self).length }
+     Returns the days of the month.
+     */
+    func monthDays () -> Int {
+        let range = Calendar.current.range(of: Calendar.Component.day, in: Calendar.Component.month, for: self)!
+        return range.upperBound - range.lowerBound
+    }
     /**
-    Returns the first day of the week.
-    */
+     Returns the first day of the week.
+     */
     func firstDayOfWeek () -> Int {
-        let distanceToStartOfWeek = NSDate.dayInSeconds() * Double(self.components().weekday - 1)
-        let interval: NSTimeInterval = self.timeIntervalSinceReferenceDate - distanceToStartOfWeek
-        return NSDate(timeIntervalSinceReferenceDate: interval).day()
+        let distanceToStartOfWeek = Date.dayInSeconds() * Double(self.components().weekday! - 1)
+        let interval: TimeInterval = self.timeIntervalSinceReferenceDate - distanceToStartOfWeek
+        return Date(timeIntervalSinceReferenceDate: interval).day()
     }
     /**
-    Returns the last day of the week.
-    */
+     Returns the last day of the week.
+     */
     func lastDayOfWeek () -> Int {
-        let distanceToStartOfWeek = NSDate.dayInSeconds() * Double(self.components().weekday - 1)
-        let distanceToEndOfWeek = NSDate.dayInSeconds() * Double(7)
-        let interval: NSTimeInterval = self.timeIntervalSinceReferenceDate - distanceToStartOfWeek + distanceToEndOfWeek
-        return NSDate(timeIntervalSinceReferenceDate: interval).day()
+        let distanceToStartOfWeek = Date.dayInSeconds() * Double(self.components().weekday! - 1)
+        let distanceToEndOfWeek = Date.dayInSeconds() * Double(7)
+        let interval: TimeInterval = self.timeIntervalSinceReferenceDate - distanceToStartOfWeek + distanceToEndOfWeek
+        return Date(timeIntervalSinceReferenceDate: interval).day()
     }
     /**
-    Returns true if a weekday.
-    */
+     Returns true if a weekday.
+     */
     func isWeekday() -> Bool {
         return !self.isWeekend()
     }
     /**
-    Returns true if weekend.
-    */
+     Returns true if weekend.
+     */
     func isWeekend() -> Bool {
-        let range = NSCalendar.currentCalendar().maximumRangeOfUnit(NSCalendarUnit.Weekday)
-        return (self.weekday() == range.location || self.weekday() == range.length)
+        let range = Calendar.current.maximumRange(of: Calendar.Component.weekday)!
+        return (self.weekday() == range.lowerBound || self.weekday() == range.upperBound - range.lowerBound)
     }
-    
-    
+
+
     // MARK: To String
-    
+
     /**
-    A string representation using short date and time style.
-    */
+     A string representation using short date and time style.
+     */
     func toString() -> String {
-        return self.toString(dateStyle: .ShortStyle, timeStyle: .ShortStyle, doesRelativeDateFormatting: false)
+        return self.toString(.short, timeStyle: .short, doesRelativeDateFormatting: false)
     }
-    
+
     /**
-    A string representation based on a format.
-    
-    - Parameter format: The format of date can be .ISO8601(.ISO8601Format?), .DotNet, .RSS, .AltRSS or Custom(FormatString).
-    - Parameter timeZone: The time zone to interpret the date can be .Local, .UTC applies to Custom format only
-    - Returns The date string representation
-    */
-    func toString(format format: DateFormat, timeZone: TimeZone = .Local) -> String
+     A string representation based on a format.
+
+     - Parameter format: The format of date can be .ISO8601(.ISO8601Format?), .DotNet, .RSS, .AltRSS or Custom(FormatString).
+     - Parameter timeZone: The time zone to interpret the date can be .Local, .UTC applies to Custom format only
+     - Returns The date string representation
+     */
+    func toString(_ format: DateFormat, timeZone: TimeZone = .local) -> String
     {
         var dateFormat: String
-        let zone: NSTimeZone
+        let zone: Foundation.TimeZone
         switch format {
-        case .DotNet:
-            let offset = NSTimeZone.defaultTimeZone().secondsFromGMT / 3600
+        case .dotNet:
+            let offset = Foundation.NSTimeZone.default.secondsFromGMT() / 3600
             let nowMillis = 1000 * self.timeIntervalSince1970
             return  "/Date(\(nowMillis)\(offset))/"
-        case .ISO8601(let isoFormat):
+        case .iso8601(let isoFormat):
             dateFormat = (isoFormat != nil) ? isoFormat!.rawValue : ISO8601Format.DateTimeMilliSec.rawValue
-            zone = NSTimeZone.localTimeZone()
-        case .RSS:
+            zone = NSTimeZone.local
+        case .rss:
             dateFormat = RSSFormat
-            zone = NSTimeZone.localTimeZone()
-        case .AltRSS:
+            zone = NSTimeZone.local
+        case .altRSS:
             dateFormat = AltRSSFormat
-            zone = NSTimeZone.localTimeZone()
-        case .Custom(let string):
+            zone = NSTimeZone.local
+        case .custom(let string):
             switch timeZone {
-            case .Local:
-                zone = NSTimeZone.localTimeZone()
-            case .UTC:
-                zone = NSTimeZone(forSecondsFromGMT: 0)
+            case .local:
+                zone = NSTimeZone.local
+            case .utc:
+                zone = Foundation.TimeZone(secondsFromGMT: 0)!
             }
             dateFormat = string
         }
-        
-        let formatter = NSDate.formatter(format: dateFormat, timeZone: zone)
-        return formatter.stringFromDate(self)
+
+        let formatter = Date.formatter(dateFormat, timeZone: zone)
+        return formatter.string(from: self)
     }
-    
+
     /**
-    A string representation based on custom style.
-    
-    - Parameter dateStyle: The date style to use.
-    - Parameter timeStyle: The time style to use.
-    - Parameter doesRelativeDateFormatting: Enables relative date formatting.
-    - Parameter timeZone: The time zone to use.
-    - Parameter locale: The locale to use.
-    - Returns A string representation of the date.
-    */
-    func toString(dateStyle dateStyle: NSDateFormatterStyle, timeStyle: NSDateFormatterStyle, doesRelativeDateFormatting: Bool = false, timeZone: NSTimeZone = NSTimeZone.localTimeZone(), locale: NSLocale = NSLocale.currentLocale()) -> String
+     A string representation based on custom style.
+
+     - Parameter dateStyle: The date style to use.
+     - Parameter timeStyle: The time style to use.
+     - Parameter doesRelativeDateFormatting: Enables relative date formatting.
+     - Parameter timeZone: The time zone to use.
+     - Parameter locale: The locale to use.
+     - Returns A string representation of the date.
+     */
+    func toString(_ dateStyle: DateFormatter.Style, timeStyle: DateFormatter.Style, doesRelativeDateFormatting: Bool = false, timeZone: Foundation.TimeZone = Foundation.NSTimeZone.local, locale: Locale = Locale.current) -> String
     {
-        let formatter = NSDate.formatter(dateStyle: dateStyle, timeStyle: timeStyle, doesRelativeDateFormatting: doesRelativeDateFormatting, timeZone: timeZone, locale: locale)
-        return formatter.stringFromDate(self)
+        let formatter = Date.formatter(dateStyle, timeStyle: timeStyle, doesRelativeDateFormatting: doesRelativeDateFormatting, timeZone: timeZone, locale: locale)
+        return formatter.string(from: self)
     }
-    
+
     /**
-    A string representation based on a relative time language. i.e. just now, 1 minute ago etc..
-    */
+     A string representation based on a relative time language. i.e. just now, 1 minute ago etc..
+     */
     func relativeTimeToString() -> String
     {
         let time = self.timeIntervalSince1970
-        let now = NSDate().timeIntervalSince1970
-        
+        let now = Date().timeIntervalSince1970
+
         let timeIsInPast = now - time > 0
-        
+
         let seconds = abs(now - time)
         let minutes = round(seconds/60)
         let hours = round(minutes/60)
         let days = round(hours/24)
-        
-        func describe(time: String) -> String {
+
+        func describe(_ time: String) -> String {
             if timeIsInPast { return "\(time) ago" }
             else { return "in \(time)" }
         }
-        
+
         if seconds < 10 {
             return NSLocalizedString("just now", comment: "Show the relative time from a date")
         } else if seconds < 60 {
             let relativeTime = NSLocalizedString(describe("%.f seconds"), comment: "Show the relative time from a date")
             return String(format: relativeTime, seconds)
         }
-        
+
         if minutes < 60 {
             if minutes == 1 {
                 return NSLocalizedString(describe("1 minute"), comment: "Show the relative time from a date")
@@ -843,7 +911,7 @@ public extension NSDate {
                 return String(format: relativeTime, minutes)
             }
         }
-        
+
         if hours < 24 {
             if hours == 1 {
                 return NSLocalizedString(describe("1 hour"), comment: "Show the relative time from a date")
@@ -852,7 +920,7 @@ public extension NSDate {
                 return String(format: relativeTime, hours)
             }
         }
-        
+
         if days < 7 {
             if days == 1 {
                 return NSLocalizedString(describe("1 day"), comment: "Show the relative time from a date")
@@ -861,98 +929,94 @@ public extension NSDate {
                 return String(format: relativeTime, days)
             }
         }
-        
+
         return self.toString()
     }
-    
+
     /**
-    A string representation of the weekday.
-    */
+     A string representation of the weekday.
+     */
     func weekdayToString() -> String {
-        let formatter = NSDate.formatter()
+        let formatter = Date.formatter()
         return formatter.weekdaySymbols[self.weekday()-1] as String
     }
-    
+
     /**
-    A short string representation of the weekday.
-    */
+     A short string representation of the weekday.
+     */
     func shortWeekdayToString() -> String {
-        let formatter = NSDate.formatter()
+        let formatter = Date.formatter()
         return formatter.shortWeekdaySymbols[self.weekday()-1] as String
     }
-    
+
     /**
-    A very short string representation of the weekday.
-    
-    - Returns String
-    */
+     A very short string representation of the weekday.
+
+     - Returns String
+     */
     func veryShortWeekdayToString() -> String {
-        let formatter = NSDate.formatter()
+        let formatter = Date.formatter()
         return formatter.veryShortWeekdaySymbols[self.weekday()-1] as String
     }
-    
+
     /**
-    A string representation of the month.
-    
-    - Returns String
-    */
+     A string representation of the month.
+
+     - Returns String
+     */
     func monthToString() -> String {
-        let formatter = NSDate.formatter()
+        let formatter = Date.formatter()
         return formatter.monthSymbols[self.month()-1] as String
     }
-    
+
     /**
-    A short string representation of the month.
-    
-    - Returns String
-    */
+     A short string representation of the month.
+
+     - Returns String
+     */
     func shortMonthToString() -> String {
-        let formatter = NSDate.formatter()
+        let formatter = Date.formatter()
         return formatter.shortMonthSymbols[self.month()-1] as String
     }
-    
+
     /**
-    A very short string representation of the month.
-    
-    - Returns String
-    */
+     A very short string representation of the month.
+
+     - Returns String
+     */
     func veryShortMonthToString() -> String {
-        let formatter = NSDate.formatter()
+        let formatter = Date.formatter()
         return formatter.veryShortMonthSymbols[self.month()-1] as String
     }
-    
-    
+
+
     // MARK: Static Cached Formatters
-    
+
     /**
-    Returns a cached static array of NSDateFormatters so that thy are only created once.
-    */
-    private class func sharedDateFormatters() -> [String: NSDateFormatter] {
+     Returns a cached static array of NSDateFormatters so that thy are only created once.
+     */
+    private static func sharedDateFormatters() -> [String: DateFormatter] {
         struct Static {
-            static var formatters: [String: NSDateFormatter]? = nil
-            static var once: dispatch_once_t = 0
-        }
-        dispatch_once(&Static.once) {
-            Static.formatters = [String: NSDateFormatter]()
+            static var formatters: [String: DateFormatter]? = [String: DateFormatter]()
         }
         return Static.formatters!
     }
-    
+
     /**
-    Returns a cached formatter based on the format, timeZone and locale. Formatters are cached in a singleton array using hashkeys generated by format, timeZone and locale.
-    
-    - Parameter format: The format to use.
-    - Parameter timeZone: The time zone to use, defaults to the local time zone.
-    - Parameter locale: The locale to use, defaults to the current locale
-    - Returns The date formatter.
-    */
-    private class func formatter(format format:String = DefaultFormat, timeZone: NSTimeZone = NSTimeZone.localTimeZone(), locale: NSLocale = NSLocale.currentLocale()) -> NSDateFormatter {
+     Returns a cached formatter based on the format, timeZone and locale. Formatters are cached in a singleton array using hashkeys generated by format, timeZone and locale.
+
+     - Parameter format: The format to use.
+     - Parameter timeZone: The time zone to use, defaults to the local time zone.
+     - Parameter locale: The locale to use, defaults to the current locale
+     - Returns The date formatter.
+     */
+    private static func formatter(_ format:String = DefaultFormat, timeZone: Foundation.TimeZone = Foundation.TimeZone.current, locale: Locale = Locale.current) -> DateFormatter {
         let hashKey = "\(format.hashValue)\(timeZone.hashValue)\(locale.hashValue)"
-        var formatters = NSDate.sharedDateFormatters()
+        var formatters = Date.sharedDateFormatters()
         if let cachedDateFormatter = formatters[hashKey] {
             return cachedDateFormatter
         } else {
-            let formatter = NSDateFormatter()
+            let formatter = DateFormatter()
             formatter.dateFormat = format
             formatter.timeZone = timeZone
             formatter.locale = locale
@@ -960,24 +1024,24 @@ public extension NSDate {
             return formatter
         }
     }
-    
+
     /**
-    Returns a cached formatter based on date style, time style and relative date. Formatters are cached in a singleton array using hashkeys generated by date style, time style, relative date, timeZone and locale.
-    
-    - Parameter dateStyle: The date style to use.
-    - Parameter timeStyle: The time style to use.
-    - Parameter doesRelativeDateFormatting: Enables relative date formatting.
-    - Parameter timeZone: The time zone to use.
-    - Parameter locale: The locale to use.
-    - Returns The date formatter.
-    */
-    private class func formatter(dateStyle dateStyle: NSDateFormatterStyle, timeStyle: NSDateFormatterStyle, doesRelativeDateFormatting: Bool, timeZone: NSTimeZone = NSTimeZone.localTimeZone(), locale: NSLocale = NSLocale.currentLocale()) -> NSDateFormatter {
-        var formatters = NSDate.sharedDateFormatters()
+     Returns a cached formatter based on date style, time style and relative date. Formatters are cached in a singleton array using hashkeys generated by date style, time style, relative date, timeZone and locale.
+
+     - Parameter dateStyle: The date style to use.
+     - Parameter timeStyle: The time style to use.
+     - Parameter doesRelativeDateFormatting: Enables relative date formatting.
+     - Parameter timeZone: The time zone to use.
+     - Parameter locale: The locale to use.
+     - Returns The date formatter.
+     */
+    private static func formatter(_ dateStyle: DateFormatter.Style, timeStyle: DateFormatter.Style, doesRelativeDateFormatting: Bool, timeZone: Foundation.TimeZone = Foundation.NSTimeZone.local, locale: Locale = Locale.current) -> DateFormatter {
+        var formatters = Date.sharedDateFormatters()
         let hashKey = "\(dateStyle.hashValue)\(timeStyle.hashValue)\(doesRelativeDateFormatting.hashValue)\(timeZone.hashValue)\(locale.hashValue)"
         if let cachedDateFormatter = formatters[hashKey] {
             return cachedDateFormatter
         } else {
-            let formatter = NSDateFormatter()
+            let formatter = DateFormatter()
             formatter.dateStyle = dateStyle
             formatter.timeStyle = timeStyle
             formatter.doesRelativeDateFormatting = doesRelativeDateFormatting
@@ -987,7 +1051,5 @@ public extension NSDate {
             return formatter
         }
     }
-    
-    
-    
 }
+


### PR DESCRIPTION
Converting AFDateHelperExetension to Swift 3.2 / 4.0 syntax. No major changes.